### PR TITLE
fix: ballooning memory usage

### DIFF
--- a/ghostty/ghosttyView.h
+++ b/ghostty/ghosttyView.h
@@ -9,6 +9,7 @@
 
 @interface ghosttyView : ScreenSaverView
 
+@property (nonatomic, strong) NSArray<NSValue *> *frameSizes;
 @property (nonatomic, strong) NSArray<NSAttributedString *> *frames;
 @property (nonatomic, assign) NSInteger currentFrameIndex;
 

--- a/ghostty/ghosttyView.m
+++ b/ghostty/ghosttyView.m
@@ -20,7 +20,13 @@
         NSBundle *thisBundle = [NSBundle bundleForClass:[self class]];
         self.frames = [loader loadFramesFromBundle:thisBundle];
         
-//        [self loadAllFrames];
+        // precompute sizes
+        NSMutableArray<NSValue *> *sizes = [NSMutableArray arrayWithCapacity:self.frames.count];
+        for (NSAttributedString *as in self.frames) {
+            [sizes addObject:[NSValue valueWithSize:[as size]]];
+        }
+        self.frameSizes = [sizes copy];
+        
         [self setAnimationTimeInterval:(1.0 / 30.0)];
         self.currentFrameIndex = 0;
     }
@@ -54,7 +60,7 @@
     NSAttributedString *currentFrame = self.frames[self.currentFrameIndex];
 
     // measure and center
-    NSSize textSize = [currentFrame size];
+    NSSize textSize = [self.frameSizes[self.currentFrameIndex] sizeValue];
     CGFloat x = NSMidX(self.bounds) - (textSize.width  / 2.0);
     CGFloat y = NSMidY(self.bounds) - (textSize.height / 2.0);
 


### PR DESCRIPTION
## Summary

This pull request addresses a memory leak and performance degradation caused by calling `[NSAttributedString size]` during each animation frame. 

- Issue: Each time `drawRect:` was called, the size of the current `NSAttributedString` entry was recalculated. Repeatedly computing layout at 30 FPS led to memory spikes and eventual slowdown.

- Solution: After loading all frames in `initWithFrame:`, compute and store the `NSSize` of each attributed string in a new frameSizes array. In `drawRect:`, retrieve the precomputed size from frameSizes instead of recalculating. 

- Result: The screensaver now runs at a stable 30 FPS without gradually slowing down or consuming excessive memory.

### Re-installation Guide

To install the updated version:

1. Follow the existing [installation steps](https://github.com/initor/ghostty-screensaver#installation) in the README.
2. Either reboot your Mac or kill the existing `legacyScreenSaver` processes in Activity Monitor. This ensures macOS will load the newly installed screensaver instead of continuing to run the cached version.