### PR TITLE
readme: add Installation Issues & Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,41 @@ A macOS screensaver that animates ASCII frames, originally inspired by [ghostty.
    - Copy or drag the `.saver` file into `System Settings → Screen Saver` or into `~/Library/Screen Savers/`.
 6. Select `Ghostty Screensaver` in your Screen Saver preferences.
 
+### Installation Issues & Troubleshooting
+
+> “App cannot be opened because the developer cannot be verified”
+
+Because Ghostty Screensaver is not distributed via the Mac App Store, macOS may block the `.saver` file when you try to install. To work around this:
+
+1. System Settings (macOS Ventura or later):
+
+- Open `System Settings → Privacy & Security`.
+- Scroll down to the “Security” section. You should see a warning about “Ghostty.saver” being blocked.
+- Click `“Open Anyway”` to allow installation.
+
+2. Security & Privacy (macOS Monterey or earlier):
+
+- Go to System Preferences → Security & Privacy → General.
+- You might see a message that says “Ghostty.saver was blocked from opening because it is not from an identified developer.”
+- Click “Open Anyway” and confirm.
+
+3. Using [Ghostty](https://ghostty.org/) 👻: If you still can’t install or macOS complains about quarantine:
+
+- Navigate to the folder where you placed `ghostty.saver`.
+- Run the following command:
+```bash
+sudo xattr -d com.apple.quarantine ghostty.saver
+```
+- Double-click the `.saver` file again to install.
+
+> [!NOTE]
+> Once installed, if the new version of the screensaver doesn’t **load** immediately, try:
+
+- Rebooting your Mac, or
+- Killing the `legacyScreenSaver` processes in Activity Monitor (search for “legacyScreenSaver” and force quit).
+
+macOS should then pick up the newly installed `.saver` file.
+
 ## Development
 
 ### Features


### PR DESCRIPTION
## Summary 

Update the `README.md` file to include an `"Installation Issues & Troubleshooting"` section to help users install the Ghostty Screensaver on macOS. 

**S/O** to the [Ghostty community](https://discord.com/channels/1005603569187160125/1328142926647132254) 