### PR TITLE
refactor: move image rendering as public API

### DIFF
--- a/GhosttyPerformanceTests/GhosttyPerformanceTests.m
+++ b/GhosttyPerformanceTests/GhosttyPerformanceTests.m
@@ -1,0 +1,54 @@
+//
+//  GhosttyPerformanceTests.m
+//  GhosttyPerformanceTests
+//
+//  Created by Wayne Wen on 1/18/25.
+//
+
+#import <XCTest/XCTest.h>
+#import "GhosttyFrameLoader.h"
+
+@interface GhosttyPerformanceTests : XCTestCase
+@property (nonatomic, strong) GhosttyFrameLoader *loader;
+@property (nonatomic, strong) NSArray<NSAttributedString *> *frames;
+@end
+
+@implementation GhosttyPerformanceTests
+
+- (void)setUp {
+    [super setUp];
+    
+    // We'll create a ghosttyView with a typical screen size for testing.
+    // Start with a 3456x2234 display.
+    self.loader = [[GhosttyFrameLoader alloc] init];
+    NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
+    self.frames = [self.loader loadFramesFromBundle:testBundle];
+}
+
+- (void)testBuildFrameImagesPerformance {
+    [self measureBlock:^{
+        NSArray<NSImage *> *images =
+            [self.loader buildFrameImagesFromAttributedStrings:self.frames];
+        XCTAssertNotNil(images);
+        XCTAssertEqual(images.count, self.frames.count);
+    }];
+}
+
+/* Test boilerplate
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+*/
+@end

--- a/ghostty.xcodeproj/project.pbxproj
+++ b/ghostty.xcodeproj/project.pbxproj
@@ -7,20 +7,38 @@
 	objects = {
 
 /* Begin PBXFileReference section */
-		9C6695532D3477390069F1CB /* ghosttyTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ghosttyTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C214C732D3C804A00A6BCE4 /* GhosttyPerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GhosttyPerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9CB1AD362D33AAA4002AB6E4 /* ghostty.saver */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ghostty.saver; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		9C214C7D2D3CA13000A6BCE4 /* Exceptions for "ghostty" folder in "GhosttyPerformanceTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				GhosttyFrameLoader.m,
+			);
+			target = 9C214C722D3C804A00A6BCE4 /* GhosttyPerformanceTests */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		9C214C742D3C804A00A6BCE4 /* GhosttyPerformanceTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = GhosttyPerformanceTests;
+			sourceTree = "<group>";
+		};
 		9CB1AD382D33AAA4002AB6E4 /* ghostty */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				9C214C7D2D3CA13000A6BCE4 /* Exceptions for "ghostty" folder in "GhosttyPerformanceTests" target */,
+			);
 			path = ghostty;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		9C6695502D3477390069F1CB /* Frameworks */ = {
+		9C214C702D3C804A00A6BCE4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -41,6 +59,7 @@
 			isa = PBXGroup;
 			children = (
 				9CB1AD382D33AAA4002AB6E4 /* ghostty */,
+				9C214C742D3C804A00A6BCE4 /* GhosttyPerformanceTests */,
 				9CB1AD372D33AAA4002AB6E4 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -49,7 +68,7 @@
 			isa = PBXGroup;
 			children = (
 				9CB1AD362D33AAA4002AB6E4 /* ghostty.saver */,
-				9C6695532D3477390069F1CB /* ghosttyTest.xctest */,
+				9C214C732D3C804A00A6BCE4 /* GhosttyPerformanceTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -67,23 +86,26 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		9C6695522D3477390069F1CB /* ghosttyTest */ = {
+		9C214C722D3C804A00A6BCE4 /* GhosttyPerformanceTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 9C6695592D3477390069F1CB /* Build configuration list for PBXNativeTarget "ghosttyTest" */;
+			buildConfigurationList = 9C214C792D3C804A00A6BCE4 /* Build configuration list for PBXNativeTarget "GhosttyPerformanceTests" */;
 			buildPhases = (
-				9C66954F2D3477390069F1CB /* Sources */,
-				9C6695502D3477390069F1CB /* Frameworks */,
-				9C6695512D3477390069F1CB /* Resources */,
+				9C214C6F2D3C804A00A6BCE4 /* Sources */,
+				9C214C702D3C804A00A6BCE4 /* Frameworks */,
+				9C214C712D3C804A00A6BCE4 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = ghosttyTest;
+			fileSystemSynchronizedGroups = (
+				9C214C742D3C804A00A6BCE4 /* GhosttyPerformanceTests */,
+			);
+			name = GhosttyPerformanceTests;
 			packageProductDependencies = (
 			);
-			productName = ghosttyTest;
-			productReference = 9C6695532D3477390069F1CB /* ghosttyTest.xctest */;
+			productName = GhosttyPerformanceTests;
+			productReference = 9C214C732D3C804A00A6BCE4 /* GhosttyPerformanceTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		9CB1AD352D33AAA4002AB6E4 /* ghostty */ = {
@@ -118,7 +140,7 @@
 				BuildIndependentTargetsInParallel = 1;
 				LastUpgradeCheck = 1620;
 				TargetAttributes = {
-					9C6695522D3477390069F1CB = {
+					9C214C722D3C804A00A6BCE4 = {
 						CreatedOnToolsVersion = 16.2;
 					};
 					9CB1AD352D33AAA4002AB6E4 = {
@@ -141,13 +163,13 @@
 			projectRoot = "";
 			targets = (
 				9CB1AD352D33AAA4002AB6E4 /* ghostty */,
-				9C6695522D3477390069F1CB /* ghosttyTest */,
+				9C214C722D3C804A00A6BCE4 /* GhosttyPerformanceTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		9C6695512D3477390069F1CB /* Resources */ = {
+		9C214C712D3C804A00A6BCE4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -164,7 +186,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		9C66954F2D3477390069F1CB /* Sources */ = {
+		9C214C6F2D3C804A00A6BCE4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -181,29 +203,27 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		9C6695572D3477390069F1CB /* Debug */ = {
+		9C214C772D3C804A00A6BCE4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = weezy.ghosttyTest;
+				PRODUCT_BUNDLE_IDENTIFIER = weezy.GhosttyPerformanceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 			};
 			name = Debug;
 		};
-		9C6695582D3477390069F1CB /* Release */ = {
+		9C214C782D3C804A00A6BCE4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = weezy.ghosttyTest;
+				PRODUCT_BUNDLE_IDENTIFIER = weezy.GhosttyPerformanceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 			};
@@ -363,14 +383,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		9C6695592D3477390069F1CB /* Build configuration list for PBXNativeTarget "ghosttyTest" */ = {
+		9C214C792D3C804A00A6BCE4 /* Build configuration list for PBXNativeTarget "GhosttyPerformanceTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9C6695572D3477390069F1CB /* Debug */,
-				9C6695582D3477390069F1CB /* Release */,
+				9C214C772D3C804A00A6BCE4 /* Debug */,
+				9C214C782D3C804A00A6BCE4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		9CB1AD302D33AAA4002AB6E4 /* Build configuration list for PBXProject "ghostty" */ = {
 			isa = XCConfigurationList;
@@ -379,7 +399,7 @@
 				9CB1AD3E2D33AAA4002AB6E4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		9CB1AD3F2D33AAA4002AB6E4 /* Build configuration list for PBXNativeTarget "ghostty" */ = {
 			isa = XCConfigurationList;
@@ -388,7 +408,7 @@
 				9CB1AD412D33AAA4002AB6E4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ghostty.xcodeproj/xcshareddata/xcschemes/GhosttyPerformanceTests.xcscheme
+++ b/ghostty.xcodeproj/xcshareddata/xcschemes/GhosttyPerformanceTests.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9C214C722D3C804A00A6BCE4"
+               BuildableName = "GhosttyPerformanceTests.xctest"
+               BlueprintName = "GhosttyPerformanceTests"
+               ReferencedContainer = "container:ghostty.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ghostty/GhosttyFrameLoader.h
+++ b/ghostty/GhosttyFrameLoader.h
@@ -25,6 +25,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSArray<NSAttributedString *> *)loadFramesFromBundle:(NSBundle *)bundle;
 
+/**
+ Converts an array of NSAttributedString frames into NSImage objects by
+ rendering each string offscreen. Useful for performance-critical code
+ (e.g. screensaver animation), as drawing a pre-rendered image is faster
+ than drawing text each frame.
+
+ @param frames An array of NSAttributedString objects
+ @return An array of NSImage objects, each containing the rendered text
+ */
+- (NSArray<NSImage *> *)buildFrameImagesFromAttributedStrings:(NSArray<NSAttributedString *> *)frames;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ghostty/GhosttyFrameLoader.m
+++ b/ghostty/GhosttyFrameLoader.m
@@ -81,6 +81,33 @@ static NSFont  *sMonospacedFont;
     return [loadedFrames copy];
 }
 
+#pragma mark - Build NSImage Array
+
+- (NSArray<NSImage *> *)buildFrameImagesFromAttributedStrings:(NSArray<NSAttributedString *> *)frames
+{
+    NSMutableArray<NSImage *> *images = [NSMutableArray arrayWithCapacity:frames.count];
+
+    for (NSAttributedString *as in frames) {
+        NSSize textSize = [as size];
+        if (NSEqualSizes(textSize, NSZeroSize)) {
+            textSize = NSMakeSize(1, 1);
+        }
+
+        NSImage *renderedImage = [[NSImage alloc] initWithSize:textSize];
+        [renderedImage lockFocus];
+
+        [[NSColor clearColor] set];
+        NSRectFill(NSMakeRect(0, 0, textSize.width, textSize.height));
+
+        [as drawAtPoint:NSZeroPoint];
+        [renderedImage unlockFocus];
+
+        [images addObject:renderedImage];
+    }
+
+    return [images copy];
+}
+
 #pragma mark - Private Helpers
 
 - (NSAttributedString *)attributedFrameFromRawHTML:(NSString *)raw

--- a/ghostty/ghosttyView.h
+++ b/ghostty/ghosttyView.h
@@ -9,8 +9,13 @@
 
 @interface ghosttyView : ScreenSaverView
 
-@property (nonatomic, strong) NSArray<NSValue *> *frameSizes;
 @property (nonatomic, strong) NSArray<NSAttributedString *> *frames;
 @property (nonatomic, assign) NSInteger currentFrameIndex;
+
+/**
+ An array of images, each rendered from the corresponding NSAttributedString.
+ Draw from this array at runtime for maximum performance.
+*/
+@property (nonatomic, strong) NSArray<NSImage *> *frameImages;
 
 @end

--- a/ghostty/ghosttyView.m
+++ b/ghostty/ghosttyView.m
@@ -20,13 +20,10 @@
         NSBundle *thisBundle = [NSBundle bundleForClass:[self class]];
         self.frames = [loader loadFramesFromBundle:thisBundle];
         
-        // precompute sizes
-        NSMutableArray<NSValue *> *sizes = [NSMutableArray arrayWithCapacity:self.frames.count];
-        for (NSAttributedString *as in self.frames) {
-            [sizes addObject:[NSValue valueWithSize:[as size]]];
-        }
-        self.frameSizes = [sizes copy];
+        // pre-compute frame into images
+        self.frameImages = [loader buildFrameImagesFromAttributedStrings:self.frames];
         
+        // initial values
         [self setAnimationTimeInterval:(1.0 / 30.0)];
         self.currentFrameIndex = 0;
     }
@@ -52,20 +49,18 @@
     [[NSColor blackColor] setFill];
     NSRectFill(rect);
 
-    if (self.frames.count == 0) {
-        NSLog(@"[ghostty] no frames to draw");
+    if (self.frameImages.count == 0) {
+        NSLog(@"[ghostty] no frame images to draw");
         return;
     }
 
-    NSAttributedString *currentFrame = self.frames[self.currentFrameIndex];
-
-    // measure and center
-    NSSize textSize = [self.frameSizes[self.currentFrameIndex] sizeValue];
-    CGFloat x = NSMidX(self.bounds) - (textSize.width  / 2.0);
-    CGFloat y = NSMidY(self.bounds) - (textSize.height / 2.0);
-
+    NSImage *currentImage = self.frameImages[self.currentFrameIndex];
+    NSSize imageSize = currentImage.size;
+    CGFloat x = NSMidX(self.bounds) - (imageSize.width  / 2.0);
+    CGFloat y = NSMidY(self.bounds) - (imageSize.height / 2.0);
+    
     // draw
-    [currentFrame drawAtPoint:NSMakePoint(x, y)];
+    [currentImage drawAtPoint:NSMakePoint(x, y) fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
 }
 
 - (void)animateOneFrame


### PR DESCRIPTION
## Summary

- Move `- (NSArray<NSImage *> *)buildFrameImagesFromAttributedStrings:(NSArray<NSAttributedString *> *)frames;` as public API to `ghostty/GhosttyFrameLoader.h`
- Add test to measure `buildFrameImagesFromAttributedStrings`