### PR TITLE
fix(memory): add autorelease pool to drawRect for stable memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,41 @@ A macOS screensaver that animates ASCII frames, originally inspired by [ghostty.
    - Copy or drag the `.saver` file into `System Settings → Screen Saver` or into `~/Library/Screen Savers/`.
 6. Select `Ghostty Screensaver` in your Screen Saver preferences.
 
+### Installation Issues & Troubleshooting
+
+> “App cannot be opened because the developer cannot be verified”
+
+Because Ghostty Screensaver is not distributed via the Mac App Store, macOS may block the `.saver` file when you try to install. To work around this:
+
+1. System Settings (macOS Ventura or later):
+
+- Open `System Settings → Privacy & Security`.
+- Scroll down to the “Security” section. You should see a warning about “Ghostty.saver” being blocked.
+- Click `“Open Anyway”` to allow installation.
+
+2. Security & Privacy (macOS Monterey or earlier):
+
+- Go to System Preferences → Security & Privacy → General.
+- You might see a message that says “Ghostty.saver was blocked from opening because it is not from an identified developer.”
+- Click “Open Anyway” and confirm.
+
+3. Using [Ghostty](https://ghostty.org/) 👻: If you still can’t install or macOS complains about quarantine:
+
+- Navigate to the folder where you placed `ghostty.saver`.
+- Run the following command:
+```bash
+sudo xattr -d com.apple.quarantine ghostty.saver
+```
+- Double-click the `.saver` file again to install.
+
+> [!NOTE]
+> Once installed, if the new version of the screensaver doesn’t **load** immediately, try:
+
+- Rebooting your Mac, or
+- Killing the `legacyScreenSaver` processes in Activity Monitor (search for “legacyScreenSaver” and force quit).
+
+macOS should then pick up the newly installed `.saver` file.
+
 ## Development
 
 ### Features
@@ -31,14 +66,6 @@ A macOS screensaver that animates ASCII frames, originally inspired by [ghostty.
 - Parses `<span class="b">...</span>` as blue `(0,0,230)`, everything else is white `(215,215,215)`.
 - Animates frames at 30 FPS.
 - Basic fallback if no frames are found.
-
-### Project Structure
-
-`ghosttyView.h/.m` – The main ScreenSaverView subclass that:
-- Loads `.txt ` frames (concurrently if desired).
-- Parses `<span class="b">` for color coding.
-- Draws each frame in `drawRect:`.
-- Animates them via `animateOneFrame`.
 
 ## Credits
 

--- a/ghostty/ghosttyView.m
+++ b/ghostty/ghosttyView.m
@@ -20,7 +20,6 @@
         NSBundle *thisBundle = [NSBundle bundleForClass:[self class]];
         self.frames = [loader loadFramesFromBundle:thisBundle];
         
-//        [self loadAllFrames];
         [self setAnimationTimeInterval:(1.0 / 30.0)];
         self.currentFrameIndex = 0;
     }
@@ -43,23 +42,25 @@
 
 - (void)drawRect:(NSRect)rect
 {
-    [[NSColor blackColor] setFill];
-    NSRectFill(rect);
+    @autoreleasepool {
+        [[NSColor blackColor] setFill];
+        NSRectFill(rect);
 
-    if (self.frames.count == 0) {
-        NSLog(@"[ghostty] no frames to draw");
-        return;
+        if (self.frames.count == 0) {
+            NSLog(@"[ghostty] no frames to draw");
+            return;
+        }
+
+        NSAttributedString *currentFrame = self.frames[self.currentFrameIndex];
+
+        // measure and center
+        NSSize textSize = [currentFrame size];
+        CGFloat x = NSMidX(self.bounds) - (textSize.width  / 2.0);
+        CGFloat y = NSMidY(self.bounds) - (textSize.height / 2.0);
+
+        // draw
+        [currentFrame drawAtPoint:NSMakePoint(x, y)];
     }
-
-    NSAttributedString *currentFrame = self.frames[self.currentFrameIndex];
-
-    // measure and center
-    NSSize textSize = [currentFrame size];
-    CGFloat x = NSMidX(self.bounds) - (textSize.width  / 2.0);
-    CGFloat y = NSMidY(self.bounds) - (textSize.height / 2.0);
-
-    // draw
-    [currentFrame drawAtPoint:NSMakePoint(x, y)];
 }
 
 - (void)animateOneFrame


### PR DESCRIPTION
### Summary  

Wraps the `drawRect` method's implementation in an `@autoreleasepool` to ensure temporary objects (e.g., Core Text buffers, measurement contexts) are released immediately after each frame. 

### Details  
- **Issue:** Long-running animations caused memory consumption to grow indefinitely, leading to performance degradation.  
- **Fix:** Added `@autoreleasepool` to `drawRect`, forcing timely cleanup of temporary objects generated during frame rendering.  
- **Impact:** Stabilizes memory usage over time, maintaining consistent performance at 30 FPS.  
