### PR TITLE
fix: flip view coordinate system to fix upside-down animation

### DIFF
--- a/ghostty/ghosttyView.m
+++ b/ghostty/ghosttyView.m
@@ -57,6 +57,14 @@
     self.lastRenderedFrameIndex = -1;
 }
 
+// NSLayoutManager draws glyphs in a flipped coordinate system (origin at
+// top-left, y increasing downward). ScreenSaverView inherits from NSView
+// which is unflipped by default, causing the animation to render upside down.
+- (BOOL)isFlipped
+{
+    return YES;
+}
+
 #pragma mark - Drawing & Animation
 
 - (void)drawRect:(NSRect)rect


### PR DESCRIPTION
## Summary
- Fix upside-down animation regression introduced in #11
- `NSLayoutManager` draws glyphs assuming a flipped coordinate system (origin top-left, y downward), but `ScreenSaverView` inherits `NSView`'s default unflipped coordinates (origin bottom-left, y upward)
- Override `-isFlipped` to return `YES` so the view matches `NSLayoutManager`'s expectations

## Test plan
- [x] Run screensaver and verify the ghostty animation renders right-side up
- [x] Verify memory fix from #11 is still intact (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)